### PR TITLE
Fixed CastSpellByName not being able to self cast

### DIFF
--- a/TotemTimers.lua
+++ b/TotemTimers.lua
@@ -557,9 +557,9 @@ function TotemTimers_SetupHooks()
 	end;
 	--Additions for hooking CastSpellByName
 	TT_HookFunctions["CastSpellByName"] = CastSpellByName;
-	CastSpellByName = function(Spell_Name)
+	CastSpellByName = function(Spell_Name,onself)
 		TotemTimers_CastSpellByName(Spell_Name);
-	TT_HookFunctions["CastSpellByName"](Spell_Name);
+		TT_HookFunctions["CastSpellByName"](Spell_Name,onself);
 	end;
 	--Additions for hooking UseInventoryItem
 	TT_HookFunctions["UseInventoryItem"] = UseInventoryItem;


### PR DESCRIPTION
CastSpellByName has a self cast option described here: https://wowwiki-archive.fandom.com/wiki/API_CastSpellByName
The argument for the self cast was missing, meaning that just by having this addon active on your character all macros of the type `CastSpellByName("spell_name",1)` would fail to self cast, and only work as a regular cast.

By adding in the missing argument self casting is now restored.

I also indented line 562 to match the formatting of the surrounding code.